### PR TITLE
change to more generic domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-factomstatus.com
+project.factom.com


### PR DESCRIPTION
Deprecated site was replaced with https://status.factom.com/